### PR TITLE
struct for artifact params and artifact extension reader and writer

### DIFF
--- a/cde/sdk/go/cmd/artifact.go
+++ b/cde/sdk/go/cmd/artifact.go
@@ -29,10 +29,10 @@ func init() {
 	artifactCmd.AddCommand(artifactPackagedCmd)
 	artifactCmd.AddCommand(artifactPublishedCmd)
 
-	artifactCmd.PersistentFlags().StringVarP(&artifactId, "id", "i", "", "Artifact Id")
-	artifactCmd.PersistentFlags().StringVarP(&artifactName, "name", "n", "", "Artifact Name")
-	artifactCmd.PersistentFlags().StringVarP(&artifactVersion, "version", "v", "", "Artifact Version")
-	artifactCmd.PersistentFlags().StringToStringVarP(&artifactData, "data", "d", map[string]string{}, "Artifact Data")
+	artifactCmd.PersistentFlags().StringVarP(&artifactParams.ArtifactId, "id", "i", "", "Artifact Id")
+	artifactCmd.PersistentFlags().StringVarP(&artifactParams.ArtifactName, "name", "n", "", "Artifact Name")
+	artifactCmd.PersistentFlags().StringVarP(&artifactParams.ArtifactVersion, "version", "v", "", "Artifact Version")
+	artifactCmd.PersistentFlags().StringToStringVarP(&artifactParams.ArtifactData, "data", "d", map[string]string{}, "Artifact Data")
 }
 
 var artifactCmd = &cobra.Command{
@@ -41,12 +41,7 @@ var artifactCmd = &cobra.Command{
 	Long:  `Emit Artifact related CloudEvent`,
 }
 
-var (
-	artifactId      string
-	artifactName    string
-	artifactVersion string
-	artifactData    map[string]string
-)
+var artifactParams = cde.ArtifactEventParams{}
 
 var artifactPackagedCmd = &cobra.Command{
 	Use:   "packaged",
@@ -60,8 +55,7 @@ var artifactPackagedCmd = &cobra.Command{
 		}
 
 		// Create an Event.
-		event, _ := cde.CreateArtifactEvent(cde.ArtifactPackagedEventV1, artifactId,
-			artifactName, artifactVersion, artifactData)
+		event, _ := cde.CreateArtifactEvent(cde.ArtifactPackagedEventV1, artifactParams)
 
 		event.SetSource(source)
 
@@ -92,8 +86,7 @@ var artifactPublishedCmd = &cobra.Command{
 		}
 
 		// Create an Event.
-		event, _ := cde.CreateArtifactEvent(cde.ArtifactPublishedEventV1, artifactId,
-			artifactName, artifactVersion, artifactData)
+		event, _ := cde.CreateArtifactEvent(cde.ArtifactPublishedEventV1, artifactParams)
 
 		event.SetSource(source)
 

--- a/cde/sdk/go/pkg/cdf/events/event_types.go
+++ b/cde/sdk/go/pkg/cdf/events/event_types.go
@@ -84,19 +84,22 @@ func (t CDEventType) String() string {
 	return string(t)
 }
 
-func CreateArtifactEvent(eventType CDEventType,
-	artifactId string,
-	artifactName string,
-	artifactVersion string,
-	artifactData map[string]string) (cloudevents.Event, error) {
+type ArtifactEventParams struct {
+	ArtifactId      string
+	ArtifactName    string
+	ArtifactVersion string
+	ArtifactData    map[string]string
+}
+
+func CreateArtifactEvent(eventType CDEventType, params ArtifactEventParams) (cloudevents.Event, error) {
 	event := cloudevents.NewEvent()
 	event.SetID(uuid.NewV4().String())
 	event.SetType(eventType.String())
 	event.SetTime(time.Now())
 
-	setExtensionForArtifactEvents(event, artifactId, artifactName, artifactVersion)
+	setExtensionForArtifactEvents(event, params.ArtifactId, params.ArtifactName, params.ArtifactVersion)
 
-	err := event.SetData(cloudevents.ApplicationJSON, artifactData)
+	err := event.SetData(cloudevents.ApplicationJSON, params.ArtifactData)
 	if err != nil {
 		return cloudevents.Event{}, err
 	}

--- a/cde/sdk/go/pkg/cdf/events/extensions/artifact_extension.go
+++ b/cde/sdk/go/pkg/cdf/events/extensions/artifact_extension.go
@@ -1,0 +1,1 @@
+package extensions

--- a/cde/sdk/go/pkg/cdf/events/extensions/artifact_extension.go
+++ b/cde/sdk/go/pkg/cdf/events/extensions/artifact_extension.go
@@ -1,1 +1,67 @@
 package extensions
+
+import (
+	"github.com/cloudevents/sdk-go/v2/binding"
+	"github.com/cloudevents/sdk-go/v2/types"
+)
+
+const (
+	ArtifactIdExtension      = "artifactid"
+	ArtifactNameExtension    = "artifactname"
+	ArtifactVersionExtension = "artifactversion"
+)
+
+// ArtifactExtension represents the extension for extension context
+type ArtifactExtension struct {
+	ArtifactId      string `json:"artifactid"`
+	ArtifactName    string `json:"artifactname"`
+	ArtifactVersion string `json:"artifactversion"`
+}
+
+func (ae *ArtifactExtension) ReadTransformer() binding.TransformerFunc {
+	return func(reader binding.MessageMetadataReader, writer binding.MessageMetadataWriter) error {
+		artifactIdExtension := reader.GetExtension(ArtifactIdExtension)
+		if artifactIdExtension != nil {
+			aeiFormatted, err := types.Format(artifactIdExtension)
+			if err != nil {
+				return err
+			}
+			ae.ArtifactId = aeiFormatted
+		}
+		artifactNameExtension := reader.GetExtension(ArtifactNameExtension)
+		if artifactNameExtension != nil {
+			aenFormatted, err := types.Format(artifactNameExtension)
+			if err != nil {
+				return err
+			}
+			ae.ArtifactName = aenFormatted
+		}
+		artifactVersionExtension := reader.GetExtension(ArtifactVersionExtension)
+		if artifactVersionExtension != nil {
+			aevFormatted, err := types.Format(artifactVersionExtension)
+			if err != nil {
+				return err
+			}
+			ae.ArtifactVersion = aevFormatted
+		}
+		return nil
+	}
+}
+
+func (ae *ArtifactExtension) WriteTransformer() binding.TransformerFunc {
+	return func(reader binding.MessageMetadataReader, writer binding.MessageMetadataWriter) error {
+		err := writer.SetExtension(ArtifactIdExtension, ae.ArtifactId)
+		if err != nil {
+			return nil
+		}
+		err = writer.SetExtension(ArtifactNameExtension, ae.ArtifactName)
+		if err != nil {
+			return nil
+		}
+		err = writer.SetExtension(ArtifactVersionExtension, ae.ArtifactVersion)
+		if err != nil {
+			return nil
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
This PR does two things: 
- Initial refactoring to use struct for parameters only for artifact to validate with @afrittoli 
- It adds a reader and writer message transformer to be able to parse the extension into a struct, only done for artifact to validate the approach, but this is needed for the cloudevent transformer 