### PR TITLE
Fix typo in artifact extension

### DIFF
--- a/cde/sdk/go/pkg/cdf/events/event_types.go
+++ b/cde/sdk/go/pkg/cdf/events/event_types.go
@@ -109,9 +109,8 @@ func CreateArtifactEvent(eventType CDEventType, params ArtifactEventParams) (clo
 
 func setExtensionForArtifactEvents(event cloudevents.Event, artifactId string, artifactName string, artifactVersion string) {
 	event.SetExtension("artifactid", artifactId)
-	event.SetExtension("artiactname", artifactName)
+	event.SetExtension("artifactname", artifactName)
 	event.SetExtension("artifactversion", artifactVersion)
-
 }
 
 func CreateBuildEvent(eventType CDEventType,


### PR DESCRIPTION
Fix a typo in the name extension for the artifacts.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>