### PR TITLE
Initial Tekton resources for the PoC

### DIFF
--- a/poc/resources/README.md
+++ b/poc/resources/README.md
@@ -7,7 +7,6 @@ If you have keptn cli installed already you can run these two commands:
 
 And instead of creating a project with the quickstart instructions the shipyard.yaml file is provided to run the following steps. 
 
-
 You need to export the two following Environment Variables: 
 
 **Note**: If you don't install istio for ingress you need to port-forward with:
@@ -27,16 +26,21 @@ Run the CLI Command: `keptn create project fmtok8s --shipyard=your_shipyard.yaml
 
 Run the CLI command: `keptn create service agenda-service --project=fmtok8s` 
 
-Now you can start the CDEvents to Ketpn Inbound Translator component () with from inside the tranlator go project (this will configure a server in port 8081 to avoid conflict with Keptn in 8080): 
+Now you can start the CDEvents to Ketpn Inbound Translator component () with from inside the translator go project (this will configure a server in port 8081 to avoid conflict with Keptn in 8080): 
 
 ```
 go build
 go run main.go
 ```
 
+You can also run the translator component in the k8s cluster:
+```bash
+export KO_DOCKER_REPO=<your-local-repo>
+ko apply -f config/
+```
+
 Using the CDE binary you can emit an CD CloudEvent to the translator layer. Make sure that you export the CDE_SINK for CDE to point to the translator endpoint: 
 `export CDE_SINK=http://localhost:8081/events`
-
 
 `cde artifact packaged --id agenda-service-rest --name agenda-service -v 0.0.20 --data artifact=hash`
 

--- a/poc/resources/README.md
+++ b/poc/resources/README.md
@@ -24,7 +24,7 @@ Then configure the bridge (this will give you the credentials for the user inter
 
 Run the CLI Command: `keptn create project fmtok8s --shipyard=your_shipyard.yaml` 
 
-Run the CLI command: `keptn create service agenda-service --project=fmtok8s` 
+Run the CLI command: `keptn create service podtato-server --project=fmtok8s` 
 
 Now you can start the CDEvents to Ketpn Inbound Translator component () with from inside the translator go project (this will configure a server in port 8081 to avoid conflict with Keptn in 8080): 
 

--- a/poc/tekton/0000_namespace.yaml
+++ b/poc/tekton/0000_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cdevents

--- a/poc/tekton/0001_serviceaccount.yaml
+++ b/poc/tekton/0001_serviceaccount.yaml
@@ -1,0 +1,82 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: triggers-minimal
+  namespace: cdevents
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "secrets"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineruns", "pipelineresources", "taskruns"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["impersonate"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cdevent-listener
+  namespace: cdevents
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cdevent-listener-triggers-minimal
+  namespace: cdevents
+subjects:
+- kind: ServiceAccount
+  name: cdevent-listener
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: triggers-minimal
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: config-map-admin
+  namespace: cdevents
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-config-map-admin
+  namespace: cdevents
+subjects:
+- kind: ServiceAccount
+  name: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: config-map-admin
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cdevent-listener-triggers
+rules:
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "triggers", "clustertriggerbindings", "clusterinterceptors"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cdevent-listener-triggers-cdevents
+subjects:
+- kind: ServiceAccount
+  name: cdevent-listener
+  namespace: cdevents
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cdevent-listener-triggers

--- a/poc/tekton/0002_eventlistener.yaml
+++ b/poc/tekton/0002_eventlistener.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: cdevent-listener
+  namespace: cdevents
+spec:
+  serviceAccountName: tekton-cdevent-listener
+  namespaceSelector:
+    matchNames: ['cdevents']

--- a/poc/tekton/0002_eventlistener.yaml
+++ b/poc/tekton/0002_eventlistener.yaml
@@ -5,6 +5,6 @@ metadata:
   name: cdevent-listener
   namespace: cdevents
 spec:
-  serviceAccountName: tekton-cdevent-listener
+  serviceAccountName: cdevent-listener
   namespaceSelector:
     matchNames: ['cdevents']

--- a/poc/tekton/0003_triggers.yaml
+++ b/poc/tekton/0003_triggers.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: Trigger
+metadata:
+  name: cdevent-artifact-published
+  namespace: cdevents
+spec:
+  interceptors:
+    - cel:
+        filter: >-
+          header.Ce-Type == "cd.artifact.packaged.v1"
+  bindings:
+    - name: artifactId
+      value: $(header.Ce-Artifactid)
+    - name: artifactName
+      value: $(header.Ce-Artifactname)
+    - name: artifactVersion
+      value: $(header.Ce-Artifactversion)
+    - name: context
+      value: $(body.context)
+    - name: keptnId
+      value: $(body.keptnid)
+  template:
+    spec:
+      params:
+        - name: artifactId
+        - name: artifactName
+        - name: artifactVersion
+        - name: context
+        - name: keptnId
+      resourceTemplates:
+        - apiVersion: "tekton.dev/v1beta1"
+          kind: PipelineRun
+          metadata:
+            generateName: "deploy-artifact-"
+          spec:
+            pipelineRef:
+              name: deploy-artifact
+            params:
+              - name: headers
+                value: $(tt.params.context)
+              - name: body
+                value: $(tt.params.keptnId)

--- a/poc/tekton/0003_triggers.yaml
+++ b/poc/tekton/0003_triggers.yaml
@@ -6,9 +6,11 @@ metadata:
   namespace: cdevents
 spec:
   interceptors:
-    - cel:
-        filter: >-
-          header.Ce-Type == "cd.artifact.packaged.v1"
+    - ref:
+        name: "cel"
+      params:
+        - name: "filter"
+          value: "header.match('Ce-Type', 'cd.artifact.published.v1')"
   bindings:
     - name: artifactId
       value: $(header.Ce-Artifactid)

--- a/poc/tekton/0004_pipelines.yaml
+++ b/poc/tekton/0004_pipelines.yaml
@@ -25,7 +25,7 @@ spec:
       default: kind-registry:5000/cdevent
     - name: target-name
       description: Name of the image to publish
-      default: agenda-service
+      default: podtato-server
     - name: version
       description: the target version to build
       default: V0.1.0

--- a/poc/tekton/0004_pipelines.yaml
+++ b/poc/tekton/0004_pipelines.yaml
@@ -40,7 +40,7 @@ spec:
       description: Docker config secret
   results:
     - name: cd.artifact.id
-      value: $(tasks.image-build.results.IMAGE-DIGEST)
+      value: $(tasks.export-results.results.artifactId)
     - name: cd.artifact.name
       value: $(tasks.export-results.results.artifactName)
     - name: cd.artifact.version
@@ -83,11 +83,14 @@ spec:
         params:
           - name: name
           - name: version
+          - name: uri
         results:
           - name: artifactName
             description: The name of the artifact
           - name: artifactVersion
             description: The version of the artifact
+          - name: artifactId
+            description: The full URL of the artifact, with version
         steps:
           - name: create-results
             image: alpine
@@ -96,18 +99,25 @@ spec:
                 value: $(results.artifactName.path)
               - name: ARTIFACT_VERSION_RESULT_PATH
                 value: $(results.artifactVersion.path)
+              - name: ARTIFACT_ID_RESULT_PATH
+                value: $(results.artifactId.path)
               - name: ARTIFACT_NAME_RESULT_VALUE
                 value: $(params.name)
               - name: ARTIFACT_VERSION_RESULT_VALUE
                 value: $(params.version)
+              - name: ARTIFACT_ID_RESULT_VALUE
+                value: $(params.uri)
             script: |
               printf "$ARTIFACT_NAME_RESULT_VALUE" > "$ARTIFACT_NAME_RESULT_PATH"
               printf "$ARTIFACT_VERSION_RESULT_VALUE" > "$ARTIFACT_VERSION_RESULT_PATH"
+              printf "$ARTIFACT_ID_RESULT_VALUE" > "$ARTIFACT_ID_RESULT_PATH"
       params:
         - name: name
           value: $(params.target-name)
         - name: version
           value: $(params.version)
+        - name: uri
+          value: $(params.target)/$(params.target-name)@$(tasks.image-build.results.IMAGE-DIGEST)
 ---
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline

--- a/poc/tekton/0004_pipelines.yaml
+++ b/poc/tekton/0004_pipelines.yaml
@@ -6,7 +6,6 @@ metadata:
     description: |
       Build the container image of the Podtato Head service
     cd.artifact.packaged: enabled
-    cd.artifact.published: enabled
 spec:
   params:
     - name: gitRepository
@@ -22,11 +21,18 @@ spec:
       description: The path to the dockerfile within the context
       default: docker/DockerfileV0.1.0
     - name: target
-      description: The target container registry image to build (without version)
-      default: uk.icr.io/tekton/podtato-server
+      description: The target container registry and path where to build the image
+      default: kind-registry:5000/cdevent
+    - name: target-name
+      description: Name of the image to publish
+      default: agenda-service
     - name: version
       description: the target version to build
       default: V0.1.0
+    - name: kanikoExtraArgs
+      type: array
+      description: extra args to pass to the kaniko builder
+      default: [--insecure-registry=kind-registry:5000]
   workspaces:
     - name: sources
       description: Workspace where the git repo is prepared for testing
@@ -59,11 +65,13 @@ spec:
         bundle: gcr.io/tekton-releases/catalog/upstream/kaniko:0.4
       params:
         - name: IMAGE
-          value: $(params.target):$(params.version)
+          value: $(params.target)/$(params.target-name):$(params.version)
         - name: CONTEXT
           value: $(params.context)
         - name: DOCKERFILE
           value: $(params.dockerfile)
+        - name: EXTRA_ARGS
+          value: ["$(params.kanikoExtraArgs[*])"]
       workspaces:
         - name: source
           workspace: sources
@@ -97,6 +105,49 @@ spec:
               printf "$ARTIFACT_VERSION_RESULT_VALUE" > "$ARTIFACT_VERSION_RESULT_PATH"
       params:
         - name: name
-          value: $(params.target)
+          value: $(params.target-name)
         - name: version
           value: $(params.version)
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: deploy-artifact
+  annotations:
+    description: |
+      Deploy the Podtato Head service
+    cd.service.deployed: enabled
+spec:
+  params:
+    - name: artifactId
+    - name: artifactName
+    - name: artifactVersion
+    - name: context
+    - name: keptnId
+    - name: envId
+  workspaces:
+    - name: kubeconfig
+      description: Kubeconfig secret
+  results:
+    - name: cd.service.envid
+      value: $(tasks.deploy.results.envId)
+    - name: cd.service.name
+      value: $(tasks.deploy.results.serviceName)
+    - name: cd.service.version
+      value: $(tasks.deploy.results.serviceVersion)
+  tasks:
+    - name: deploy
+      taskSpec:
+        params:
+          - name: envid
+          - name: name
+          - name: version
+        results:
+          - name: envId
+          - name: serviceName
+          - name: serviceVersion
+        steps:
+          - name: noop
+            image: alpine
+            script: |
+              echo "I'm not doing anything..."

--- a/poc/tekton/README.md
+++ b/poc/tekton/README.md
@@ -1,0 +1,99 @@
+# Tekton Resources
+
+This folder contains all the Tekton resources required for the PoC.
+
+## Prerequisites
+
+### Install Tekton
+
+Set up a kind cluster with Tekton using [tekton_in_kind.sh](tekton_in_kind.sh).
+Alternatively:
+
+1. Install Tekton Pipeline:
+```bash
+kubectl apply -f https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.25.0/release.yaml
+```
+
+2. Install Tekton Triggers:
+```bash
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/previous/v0.14.2/release.yaml
+kubectl apply -f https://storage.googleapis.com/tekton-releases/triggers/previous/v0.14.2/interceptors.yaml
+```
+
+3. Install Tekton Dashboard (optional):
+```bash
+kubectl apply -f https://github.com/tektoncd/dashboard/releases/download/v0.17.0/tekton-dashboard-release.yaml
+```
+
+### Configure Tekton Pipeline
+
+The Tekton pipeline uses some alpha features (Tekton Bundles) which needs to
+be enabled in the config. The `feature-flags` config map in the `tekton-pipelines` namespace
+should look like:
+
+```yaml
+apiVersion: v1
+data:
+  enable-api-fields: alpha # <------- 
+  disable-affinity-assistant: "false"
+  disable-creds-init: "false"
+  disable-home-env-overwrite: "true"
+  disable-working-directory-overwrite: "true"
+  enable-custom-tasks: "false"
+  enable-tekton-oci-bundles: "false"
+  require-git-ssh-secret-known-hosts: "false"
+  running-in-environment-with-injected-sidecars: "true"
+kind: ConfigMap
+(...)
+```
+
+### Install Tekton CloudEvents Controller
+
+Nightly builds are not available yet, so this has to be installed from source.
+Requires:
+
+- go 1.16+
+- `GO111MODULE=on`
+- [`ko`](https://github.com/google/ko)
+
+Clone the [tekton experimental repo](https://github.com/tektoncd/experimental).
+
+Setup `KO_DOCKER_REPO` to point to your container registry (or `kind.local` when using kind).
+Note than when using a private container registry, the tekton cloudevents controller service account
+will need to have access via `imagePullSecrets`.
+
+Move to the cloned folder:
+```
+cd cloudevents
+ko apply -f config/
+```
+
+### Configure Tekton CloudEvents Controller
+
+The `config-defaults` config map in the `tekton-cloudevents` namespace should look like:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+data:
+  default-cloud-events-sink: http://<endpoint of cloudevents listener on keptn side>
+(...)
+```
+
+## Install Tekton Resources
+
+Install all the yaml files:
+
+```bash
+kubectl create -f poc/tekton
+```
+
+## Run the build pipeline
+
+Prerequisites:
+- `tkn` (github.com/tektoncd/cli)
+- Push access to a container registry. The `dockerconfig` secret in the example below is called `regcred`
+
+```bash
+tkn pipeline start build-artifact -w name=sources,volumeClaimTemplateFile=poc/tekton/workspace-template.yaml -w name=dockerconfig,secret=regcred
+```

--- a/poc/tekton/pipeline.yaml
+++ b/poc/tekton/pipeline.yaml
@@ -1,0 +1,102 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-artifact
+  annotations:
+    description: |
+      Build the container image of the Podtato Head service
+    cd.artifact.packaged: enabled
+    cd.artifact.published: enabled
+spec:
+  params:
+    - name: gitRepository
+      description: The git repository that hosts context and Dockerfile
+      default: https://github.com/cncf/podtato-head
+    - name: gitRevision
+      description: The git revision to build
+      default: main
+    - name: context
+      description: The path to the docker context in the sources workspace
+      default: podtato-server
+    - name: dockerfile
+      description: The path to the dockerfile within the context
+      default: docker/DockerfileV0.1.0
+    - name: target
+      description: The target container registry image to build (without version)
+      default: uk.icr.io/tekton/podtato-server
+    - name: version
+      description: the target version to build
+      default: V0.1.0
+  workspaces:
+    - name: sources
+      description: Workspace where the git repo is prepared for testing
+    - name: dockerconfig
+      description: Docker config secret
+  results:
+    - name: cd.artifact.id
+      value: $(tasks.image-build.results.IMAGE-DIGEST)
+    - name: cd.artifact.name
+      value: $(tasks.export-results.results.artifactName)
+    - name: cd.artifact.version
+      value: $(tasks.export-results.results.artifactVersion)
+  tasks:
+    - name: clone-repo
+      taskRef:
+        name: git-clone
+        bundle: gcr.io/tekton-releases/catalog/upstream/git-clone:0.4
+      params:
+        - name: url
+          value: $(params.gitRepository)
+        - name: revision
+          value: $(params.gitRevision)
+      workspaces:
+        - name: output
+          workspace: sources
+    - name: image-build
+      runAfter: [clone-repo]
+      taskRef:
+        name: kaniko
+        bundle: gcr.io/tekton-releases/catalog/upstream/kaniko:0.4
+      params:
+        - name: IMAGE
+          value: $(params.target):$(params.version)
+        - name: CONTEXT
+          value: $(params.context)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+      workspaces:
+        - name: source
+          workspace: sources
+        - name: dockerconfig
+          workspace: dockerconfig
+    - name: export-results
+      runAfter: [image-build]
+      taskSpec:
+        params:
+          - name: name
+          - name: version
+        results:
+          - name: artifactName
+            description: The name of the artifact
+          - name: artifactVersion
+            description: The version of the artifact
+        steps:
+          - name: create-results
+            image: alpine
+            env:
+              - name: ARTIFACT_NAME_RESULT_PATH
+                value: $(results.artifactName.path)
+              - name: ARTIFACT_VERSION_RESULT_PATH
+                value: $(results.artifactVersion.path)
+              - name: ARTIFACT_NAME_RESULT_VALUE
+                value: $(params.name)
+              - name: ARTIFACT_VERSION_RESULT_VALUE
+                value: $(params.version)
+            script: |
+              printf "$ARTIFACT_NAME_RESULT_VALUE" > "$ARTIFACT_NAME_RESULT_PATH"
+              printf "$ARTIFACT_VERSION_RESULT_VALUE" > "$ARTIFACT_VERSION_RESULT_PATH"
+      params:
+        - name: name
+          value: $(params.target)
+        - name: version
+          value: $(params.version)

--- a/poc/tekton/tekton_in_kind.sh
+++ b/poc/tekton/tekton_in_kind.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+set -e -o pipefail
+
+declare TEKTON_PIPELINE_VERSION TEKTON_TRIGGERS_VERSION TEKTON_DASHBOARD_VERSION
+declare KNATIVE_VERSION KNATIVE_NET_KOURIER_VERSION
+
+# This script deploys Tekton on a local kind cluster
+# It creates a kind cluster and deploys pipeline, triggers and dashboard
+
+# Prerequisites:
+# - go 1.15+
+# - docker (recommended 8GB memory config)
+# - kind
+
+# Notes:
+# - Latest versions will be installed if not specified
+# - If a kind cluster named "tekton" already exists this will fail
+# - Local access to the dashboard requires port 9097 to be locally available
+
+get_latest_release() {
+  curl --silent "https://api.github.com/repos/$1/releases/latest" | # Get latest release from GitHub api
+    grep '"tag_name":' |                                            # Get tag line
+    sed -E 's/.*"([^"]+)".*/\1/'                                    # Pluck JSON value
+}
+
+# Read command line options
+while getopts ":c:p:t:d:k:" opt; do
+  case ${opt} in
+    c )
+      CLUSTER_NAME=$OPTARG
+      ;;
+    p )
+      TEKTON_PIPELINE_VERSION=$OPTARG
+      ;;
+    t )
+      TEKTON_TRIGGERS_VERSION=$OPTARG
+      ;;
+    d )
+      TEKTON_DASHBOARD_VERSION=$OPTARG
+      ;;
+    k )
+      KNATIVE_VERSION=$OPTARG
+      ;;
+    \? )
+      echo "Invalid option: $OPTARG" 1>&2
+      echo 1>&2
+      echo "Usage:  tekton_in_kind.sh [-c cluster-name -p pipeline-version -t triggers-version -d dashboard-version -i kourier|nginx -k knative-version]"
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
+# Check and defaults input params
+export KIND_CLUSTER_NAME=${CLUSTER_NAME:-"tekton"}
+
+if [ -z "$TEKTON_PIPELINE_VERSION" ]; then
+  TEKTON_PIPELINE_VERSION=$(get_latest_release tektoncd/pipeline)
+fi
+if [ -z "$TEKTON_TRIGGERS_VERSION" ]; then
+  TEKTON_TRIGGERS_VERSION=$(get_latest_release tektoncd/triggers)
+fi
+if [ -z "$TEKTON_DASHBOARD_VERSION" ]; then
+  TEKTON_DASHBOARD_VERSION=$(get_latest_release tektoncd/dashboard)
+fi
+if [ -z "$KNATIVE_VERSION" ]; then
+  MAIN_CONTAINER_HTTP_PORT=80
+  MAIN_CONTAINER_HTTPS_PORT=443
+  ALT_CONTAINER_HTTP_PORT=22222 # unused
+  ALT_CONTAINER_HTTPS_PORT=22223 # unused
+  TEKTON_PORT=80
+else
+  MAIN_CONTAINER_HTTP_PORT=31080
+  MAIN_CONTAINER_HTTPS_PORT=31443
+  ALT_CONTAINER_HTTP_PORT=80
+  ALT_CONTAINER_HTTPS_PORT=443
+  TEKTON_PORT=8080
+fi
+
+echo "===> Creating a Kind Cluster"
+# create registry container unless it already exists
+reg_name='kind-registry'
+reg_port='5000'
+running="$(docker inspect -f '{{.State.Running}}' "${reg_name}" 2>/dev/null || true)"
+if [ "${running}" != 'true' ]; then
+  docker run \
+    -d --restart=always -p "${reg_port}:5000" --name "${reg_name}" \
+    registry:2
+fi
+
+# Create the kind cluster
+# create a cluster with the local registry enabled in containerd
+running_cluster=$(kind get clusters | grep tekton || true)
+if [ "${running_cluster}" != "$KIND_CLUSTER_NAME" ]; then
+ cat <<EOF | kind create cluster --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+    extraPortMappings:
+      - containerPort: $MAIN_CONTAINER_HTTP_PORT
+        hostPort: 80
+        protocol: TCP
+      - containerPort: $MAIN_CONTAINER_HTTPS_PORT
+        hostPort: 443
+        protocol: TCP
+      - containerPort: $ALT_CONTAINER_HTTP_PORT
+        hostPort: 8080
+        protocol: TCP
+      - containerPort: $ALT_CONTAINER_HTTPS_PORT
+        hostPort: 8443
+        protocol: TCP
+  - role: worker
+featureGates:
+  "EphemeralContainers": true
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]
+    endpoint = ["http://${reg_name}:${reg_port}"]
+EOF
+fi
+
+# connect the registry to the cluster network
+# (the network may already be connected)
+docker network connect "kind" "${reg_name}" || true
+
+if [ -n "$KNATIVE_VERSION" ]; then
+  echo "===> Deploying Knative controller"
+  export KNATIVE_VERSION
+  curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/02-serving.sh | sh
+
+  echo "===> Deploying Kourier"
+  export KNATIVE_NET_KOURIER_VERSION=${KNATIVE_NET_KOURIER_VERSION:-$KNATIVE_VERSION}
+  curl -sL https://raw.githubusercontent.com/csantanapr/knative-kind/master/02-kourier.sh | sh
+
+  EXTERNAL_IP="127.0.0.1"
+  KNATIVE_DOMAIN="$EXTERNAL_IP.nip.io"
+  kubectl patch configmap -n knative-serving config-domain -p "{\"data\": {\"$KNATIVE_DOMAIN\": \"\"}}"
+fi
+
+echo "===> Deploying the Ingress controller"
+# Deploy the ingress
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=160s
+
+echo "===> RBAC and secrets"
+# Install some basic RBAC and secrets needed by triggers
+kubectl create -f rbac.yaml || true
+if [ -f .secrets/icr.yaml ]; then
+  kubectl create -f .secrets/icr.yaml || true
+  kubectl patch serviceaccount default -p '{"imagePullSecrets": [{"name": "all-icr-io"}]}' || true
+fi
+if [ -f .secrets/config.json ]; then
+  kubectl create secret generic regcred \
+    --from-file=config.json=.secrets/config.json \
+    --from-file=.dockerconfigjson=.secrets/config.json \
+    --type=kubernetes.io/dockerconfigjson || true
+fi
+
+kubectl create namespace tekton-pipelines || true
+
+cat <<EOF | kubectl create -f -
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tekton-dashboard
+  namespace: tekton-pipelines
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /\$2
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^(/[a-z1-9\-]*)$ \$1/ redirect;
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /dashboard(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: tekton-dashboard
+            port:
+              number: 9097
+EOF
+
+echo "===> Install Tekton"
+
+echo export TEKTON_PIPELINE_VERSION="$TEKTON_PIPELINE_VERSION"
+echo export TEKTON_TRIGGERS_VERSION="$TEKTON_TRIGGERS_VERSION"
+echo export TEKTON_DASHBOARD_VERSION="$TEKTON_DASHBOARD_VERSION"
+
+# Install Tekton Pipeline, Triggers and Dashboard
+kubectl apply -f "https://storage.googleapis.com/tekton-releases/pipeline/previous/${TEKTON_PIPELINE_VERSION}/release.yaml"
+kubectl apply -f "https://storage.googleapis.com/tekton-releases/triggers/previous/${TEKTON_TRIGGERS_VERSION}/release.yaml"
+kubectl apply -f "https://github.com/tektoncd/dashboard/releases/download/${TEKTON_DASHBOARD_VERSION}/tekton-dashboard-release.yaml"
+
+if [ -f .secrets/icr.yaml ]; then
+  kubectl create -f .secrets/icr.yaml -n tekton-pipelines || true
+  kubectl patch serviceaccount tekton-pipelines-controller -n tekton-pipelines -p '{"imagePullSecrets": [{"name": "all-icr-io"}]}' || true
+fi
+
+# # Wait until all pods are ready
+kubectl wait -n tekton-pipelines --for=condition=ready pods --all --timeout=120s
+
+echo Tekton Dashboard available at http://localhost:"${TEKTON_PORT}"/dashboard/ after installation

--- a/poc/tekton/workspace-template.yaml
+++ b/poc/tekton/workspace-template.yaml
@@ -1,0 +1,6 @@
+spec:
+ accessModes:
+   - ReadWriteOnce
+ resources:
+   requests:
+     storage: 1Gi


### PR DESCRIPTION
Add an initial pipeline to build a container image for the PoC.

The pipeline builds the CNCF podtato head app and generates
serveral CD Events:
- pipeline queued
- pipeline started
- pipeline finished
- artifact packaged

More Tekton resources for the PoC:
- event listener, trigger (and related namespace/serviceaccount/rbac)
- deploy pipeline (WIP)

Add a README.md with intructions and a script to install tekton.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>