### PR TITLE
Update source code change terminology

### DIFF
--- a/vocabulary-draft/source-code-version-control.md
+++ b/vocabulary-draft/source-code-version-control.md
@@ -16,7 +16,7 @@ These events are related to Source Code repositories
 
 
 Repository Events MUST include the following attributes:
-- **Event Type**: the type is restricted to include `cd.**` prefix. For example `cd.repository.created` or `cd.repository.changeapproved`
+- **Event Type**: the type is restricted to include `cd.**` prefix. For example `cd.repository.created` or `cd.repository.changeproposalreviewed`
 - **Repository URL**: indicates the location of the source code repository for API operations, this URL needs to include the protocol used to connect to the repository. For example `git://` , `ssh://`, `https://`
 - **Repository Name**: friendly name to list this repository to users
 
@@ -24,13 +24,17 @@ Optional attributes:
 - **Repository Owner**: indicates who is the owner of the repository, usually a `user` or an `organization`
 - **Repository View URL**: URL to access the repository from a user web browser
 
-From each repository you can emit events related with proposed source code changes. Each change can include a single or multiple commits that can also be tracked. 
+## Change and change proposal events
 
-- **Change Created Event**: a source code change was created and submitted to a repository specific branch. Examples: PullRequest sent to Github, MergeRequest sent to Gitlab, Change created in Gerrit
-- **Change Reviewed Event**:  someone (user) or an automated system submitted an review to the source code change. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change to be merged or rejected. The review event needs to include if the change is approved by the reviewer, more changes are needed or if the change is rejected.     
-- **Change Merged Event**: the change is merged to the target branch where it was submitted. 
-- **Change Abandoned Event**: a tool or a user decides that the change has been inactive for a while and it can be considered abandoned.
-- **Change Updated**: the Change has been updated, for example a new commit is added or removed from an existing Change
+From each repository you can emit events related with proposed and/or merged source code changes. Each change can include a single or multiple commits that can also be tracked.
+
+We use the term "change proposal" to represent one or more commits that form a proposal for a change to the source (e.g. a Pull Request in GitHub, a Merge Request in GitLab or a Change in Gerrit.), which becomes a change through approval and merge.
+
+- **Change Proposal Created Event**: a source code change proposal was created and submitted to a repository specific branch.
+- **Change Proposal Reviewed Event**: someone (user) or an automated system submitted a review to the source code change proposal. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change proposal to be merged or rejected. The review event needs to include if the change proposal is approved by the reviewer, more changes are needed or if the change proposal is rejected.
+- **Change Proposal Abandoned Event**: a tool or a user decides that the change proposal should be abandoned, for instance because it has been inactive for a while.
+- **Change Proposal Updated**: the change proposal has been updated, for example a new commit is added or removed from an existing change proposal.
+- **Change Merged Event**: the change proposal is made a change by it being merged to the target branch where it was submitted.
 
 
 Optional attributes for **Change** Events: 

--- a/vocabulary-draft/source-code-version-control.md
+++ b/vocabulary-draft/source-code-version-control.md
@@ -33,9 +33,9 @@ We use the term "change proposal" to represent one or more commits that form a p
 - **Change Proposal Created Event**: a source code change proposal was created and submitted to a repository specific branch.
 - **Change Proposal Reviewed Event**: someone (user) or an automated system submitted a review to the source code change proposal. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change proposal to be merged or rejected. The review event needs to include if the change proposal is approved by the reviewer, more changes are needed or if the change proposal is rejected.
 - **Change Proposal Abandoned Event**: a tool or a user decides that the change proposal should be abandoned, for instance because it has been inactive for a while.
-- **Change Proposal Updated**: the change proposal has been updated, for example a new commit is added or removed from an existing change proposal.
+- **Change Proposal Updated Event**: the change proposal has been updated, for example a new commit is added or removed from an existing change proposal.
 - **Change Proposal Merged Event**: the change proposal is merged to its target branch.
 
 
-Optional attributes for **Change** Events: 
+Optional attributes for **Change Proposal** Events: 
 - (TBD)

--- a/vocabulary-draft/source-code-version-control.md
+++ b/vocabulary-draft/source-code-version-control.md
@@ -24,17 +24,17 @@ Optional attributes:
 - **Repository Owner**: indicates who is the owner of the repository, usually a `user` or an `organization`
 - **Repository View URL**: URL to access the repository from a user web browser
 
-## Change and change proposal events
+## Change proposal events
 
-From each repository you can emit events related with proposed and/or merged source code changes. Each change can include a single or multiple commits that can also be tracked.
+From each repository you can emit events related with proposed source code changes. Each change can include a single or multiple commits that can also be tracked.
 
-We use the term "change proposal" to represent one or more commits that form a proposal for a change to the source (e.g. a Pull Request in GitHub, a Merge Request in GitLab or a Change in Gerrit.), which becomes a change through approval and merge.
+We use the term "change proposal" to represent one or more commits that form a proposal for a change to the source (e.g. [a Pull Request in GitHub, a Merge Request in GitLab or a Change in Gerrit](https://github.com/cdfoundation/sig-interoperability/blob/master/docs/vocabulary.md#scm-tools-and-technologies).), which becomes a change through approval and merge.
 
 - **Change Proposal Created Event**: a source code change proposal was created and submitted to a repository specific branch.
 - **Change Proposal Reviewed Event**: someone (user) or an automated system submitted a review to the source code change proposal. A user or an automated system needs to be in charge of understanding how many approvals/rejections are needed for this change proposal to be merged or rejected. The review event needs to include if the change proposal is approved by the reviewer, more changes are needed or if the change proposal is rejected.
 - **Change Proposal Abandoned Event**: a tool or a user decides that the change proposal should be abandoned, for instance because it has been inactive for a while.
 - **Change Proposal Updated**: the change proposal has been updated, for example a new commit is added or removed from an existing change proposal.
-- **Change Merged Event**: the change proposal is made a change by it being merged to the target branch where it was submitted.
+- **Change Proposal Merged Event**: the change proposal is merged to its target branch.
 
 
 Optional attributes for **Change** Events: 


### PR DESCRIPTION
PR to rename source code change to source code change proposal, as per discussion https://github.com/cdfoundation/sig-events/discussions/34

Note: The Change Merged event is not referred to as a proposal. My reasoning is that it stops being a proposal and becomes an actual change when it is being merged. But I don't have a strong opinion on it, it might be better to refer to it as a change proposal here as well, for consistency.