### PR TITLE
Fix the Slack invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ New members are advised to:
 
 - Join the [SIG](https://lists.cd.foundation/g/sig-events) and
 [CDF TOC](https://lists.cd.foundation/g/cdf-toc) mailing lists.
-- Join the [CDF Slack](https://join.slack.com/t/cdeliveryfdn/shared_invite/zt-ao8y4qhd-BQcTUg5l7m0HxXyBvJrT4w%20) and jump into the [#sig-events channel](https://cdeliveryfdn.slack.com/archives/C0151BTKEJX) and introduce yourself.
+- Join the [CDF Slack](https://join.slack.com/t/cdeliveryfdn/shared_invite/zt-nwc0jjd0-G65oEpv5ynFfPD5oOX5Ogg) and jump into the [#sig-events channel](https://cdeliveryfdn.slack.com/archives/C0151BTKEJX) and introduce yourself.
 - Go through the [README.md](README.md) document.
 - Regularly join the SIG meetings.
 - Submit a PR to add yourself to the [members list](#members).


### PR DESCRIPTION
The current slack invite link is restricted to a selection of email domains.
Change that to a generic invite link that allows all domains.

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>