### PR TITLE
Add Kevin Chu to list of members

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Current members:
 - Fredrik Fristedt [@fredjn](https://github.com/fredjn), Axis Communications
 - Oleg Nenashev [@oleg-nenashev](https://github.com/oleg-nenashev), [Dynatrace](https://www.dynatrace.com/)/[Jenkins](https://jenkins.io)/[Keptn](https://keptn.sh)
 - Kara de la Marck [@MarckK](https://github.com/MarckK), Continuous Delivery Foundation
+- Kevin Chu [@kbychu](https://github.com/kbychu), [GitLab](https://gitlab.com/)
 
 ### New Members
 


### PR DESCRIPTION
This PR adds Kevin Chu to the list of members for the CDF Events SIG